### PR TITLE
dev target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ up: $(IN)
 		@NB_UID=${NB_UID} docker-compose\
 			up
 
+dev: $(IN)
+	@NB_UID=${NB_UID} docker-compose\
+		-f docker-compose.dev.yml\
+		up
+
 strip: $(IN)
 		@NB_UID=${NB_UID} docker-compose\
 			-f docker-compose.yml\

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,52 @@
+version: "3"
+
+networks:
+  probcomp:
+volumes:
+  dhparam:
+    driver: local
+
+services:
+  nginx-proxy:
+    image: jwilder/nginx-proxy:0.6.0
+    networks:
+      - probcomp
+    environment:
+      CERT_NAME: probcomp.dev
+    ports:
+      - "8080:80"
+      - "8443:443"
+    volumes:
+      - dhparam:/etc/nginx/dhparam:rw
+      - ./certs:/etc/nginx/certs:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+  bayesrest:
+    working_dir: "/app"
+    build: ../bayesrest
+    networks:
+      - probcomp
+    environment:
+      PYTHONPATH: '/app'
+      CONFIG_FILE_PATH: '/app/config-example.yaml'
+      BDB_FILE: '/app/bdb/database.bdb'
+      TABLE_NAME: 'data'
+      POPULATION_NAME: 'data'
+    volumes:
+      - ../bayesrest:/app
+      - ./bdb:/app/bdb
+    ports:
+      - "5000:5000"
+  notebook:
+    build: .
+    networks:
+      - probcomp
+    ports:
+      - "8888:8888"
+    user: root
+    environment:
+      NB_UID: ${NB_UID}
+    volumes:
+      - ./work:/home/jovyan/work
+    depends_on:
+      - bayesrest
+      - nginx-proxy


### PR DESCRIPTION
This allows us to easily spin up a notebook instances backed by a locally-checked-out version of Bayesrest (must be at the relative path `../bayesrest/`), rather than using the Dockerhub bayesrest container, allowing us to work on the notebook and the API in parallel.